### PR TITLE
Fix ilo4 singlepsu

### DIFF
--- a/health_monitoring_plugins/check_snmp_ilo4/check_snmp_ilo4.py
+++ b/health_monitoring_plugins/check_snmp_ilo4/check_snmp_ilo4.py
@@ -330,12 +330,8 @@ def check_ps():
         for x, state in enumerate(ps_data, 1):
             # human readable status
             hr_status = normal_state[int(state)]
-            if  hr_status != "ok":
-                # if the power supply is ok, we will set a critical status and add it to the summary
-                helper.add_summary('Power supply status %s: %s' % (x, hr_status))
-                helper.status(critical)
-            else:
-                # if everything is ok, we increase the ps_ok_count
+            if hr_status == "ok":
+                # if the power supply is ok, we increase the ps_ok_count
                 ps_ok_count += 1
             
             # we always want to see the status in the long output

--- a/health_monitoring_plugins/check_snmp_ilo4/check_snmp_ilo4.py
+++ b/health_monitoring_plugins/check_snmp_ilo4/check_snmp_ilo4.py
@@ -349,7 +349,8 @@ def check_power_redundancy():
     The check is skipped if --noPowerRedundancy is set
     """
     # skip the check if --noPowerRedundancy is set
-    if power_redundancy_flag:
+    # Also a 1-supply configuration can never be redundant...
+    if power_redundancy_flag and int(input_pwr_sply) > 1:
         # walk the data        
         ps_redundant_data = walk_data(sess, oid_ps_redundant, helper)[0]
         


### PR DESCRIPTION
The check_snmp_ilo4 doesn't quite work right with single power supply.

Issue 1: The check_ps function doesn't properly deal with missing supplies, so I simplified the logic a little bit.

Issue 2: There's no need to check power supply redundancy when there's only 1 supply, so we can always skip this.

Even with these fixes I have to manually use --noPowerSupply and --noSystem but I think this is just due to how ILO4 works...