### PR TITLE
Handle SNMP community for Version 1 and 2

### DIFF
--- a/health_monitoring_plugins/check_snmp_idrac/check_snmp_idrac.py
+++ b/health_monitoring_plugins/check_snmp_idrac/check_snmp_idrac.py
@@ -227,7 +227,7 @@ if __name__ == '__main__':
     # The default return value should be always OK
     helper.status(ok)
 
-    sess = netsnmp.Session(Version=version, DestHost=host, SecLevel = seclevel,  SecName = secname, AuthProto = authproto, AuthPass = authpass, PrivProto = privproto, PrivPass = privpass)       
+    sess = netsnmp.Session(Version=version, DestHost=host, Community = community, SecLevel = seclevel,  SecName = secname, AuthProto = authproto, AuthPass = authpass, PrivProto = privproto, PrivPass = privpass)       
 
     user_assigned_name_data = get_data(sess, oid_user_assigned_name, helper)
     product_type_data = get_data(sess, oid_product_type, helper)


### PR DESCRIPTION
Session is not using Community so Version 1 and 2 fails with `snmpget failed - no data`, adding it allows the script to run correctly.