### PR TITLE
Fix GPS output

### DIFF
--- a/health_monitoring_plugins/meinberg.py
+++ b/health_monitoring_plugins/meinberg.py
@@ -128,7 +128,7 @@ class Meinberg(object):
         gps_position = helper.get_snmp_value_or_exit(sess, helper, self.oids['oid_gps_position'])
 
         if gps_position:
-            helper.add_summary(gps_position)
+            helper.add_summary(str(gps_position))
         else:
             helper.add_summary("Could not retrieve GPS position")
             helper.status(unknown)


### PR DESCRIPTION
The GPS output wasn't converted to a string, so eventually get_summary in pynagPlugins would fail with:
TypeError: sequence item 0: expected str instance, bytes found